### PR TITLE
feat: Router params mapping with regular expression 

### DIFF
--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -1,7 +1,11 @@
 import { ComponentObject, HandlerFunc } from './types'
 import { createRouterComponent } from './createComponent'
+import { cleanPath, isObject, includes } from './utils'
 
 let params: Record<string, string> = Object.create(null)
+
+const REGEX_PARAMS = /([:*])(\w+)/g;
+const REGEX_REPLACE_VAR = "([^/]+)";
 
 export function getParams() {
   return params
@@ -26,59 +30,66 @@ export function useRouter(routesArray: Route[]): Router {
   const routes: Record<string, ComponentObject> = Object.create(null)
 
   for (const r of routesArray) {
-    while(r.path.startsWith('/')) {
-      r.path = r.path.substring(1);
-    }
+    r.path = cleanPath(r.path)
     routes[r.path] = r.component
   }
 
   function getPath(): string {
-    params = Object.create(null)
+    return cleanPath(location.hash)
+  }
 
-    let path = location.hash
-    while(path.startsWith('/') || path.startsWith('#')) {
-      path = path.substring(1);
-    }
-    while(path.endsWith('/')) {
-      path = path.substring(0, path.length - 1);
-    }
-    return path
+  function regexToParams(match: any, names: string[]) {
+    if (names.length === 0) return null;
+    if (!match) return null;
+
+    // filter params, skip full match string -> params mapping
+    const matchInfo = match.slice(1, match.length); 
+    return matchInfo.reduce((paramObj: any, value: string, index: number) => {
+      const name = names[index];
+      paramObj[name] = value
+      return paramObj
+    }, {})
+  }
+
+  function createParamsPattern(routerPath: string) {
+    // posts/:id -> posts/([^/]+)
+
+    const paramNames: string[] = []
+    const pattern = routerPath.replace(REGEX_PARAMS, (_1, _2, name: string) => {
+      paramNames.push(name)
+      return REGEX_REPLACE_VAR
+    })
+    return { paramNames, pattern }
   }
 
   function match(browserPath: string, selector: string): void {
-    if (typeof routes[browserPath] === "object") {
+    if (isObject(routes[browserPath])) {
       createRouterComponent(routes[browserPath], selector)
       return
     }
 
-    const routerPaths = Object.keys(routes)
-    for (const routerPath of routerPaths) {
-      if (routerPath.includes(':')) {
-        const browserPathGroup = browserPath.split('/')
-        const routerPathGroups = routerPath.split('/')
-        const listPathParamPositions: number[] = []
-        routerPathGroups.forEach((g, i) => {
-          if (g.startsWith(':')) {
-            listPathParamPositions.push(i)
-          }
-        })
-        listPathParamPositions.forEach(i => {
-          browserPathGroup[i] = routerPathGroups[i]
-        })
-        if (browserPathGroup.join('/') === routerPath) {
-          const originalBrowserPathGroup = browserPath.split('/')
-          listPathParamPositions.forEach(i => {
-            params[routerPathGroups[i].substring(1)] = originalBrowserPathGroup[i]
-          })
+    // Assign url params
+    params = Object.create(null)
+    for (const routerPath of Object.keys(routes)) {
+      // browerPath = 'posts/37739/ahihi-post';
+      // routerPath = 'posts/:id'
+
+      if (includes(routerPath, ":")) {
+        const { pattern, paramNames } = createParamsPattern(routerPath)
+        const regexp = new RegExp(pattern)
+        const match = browserPath.match(regexp)
+  
+        if (match) {
+          params = regexToParams(match, paramNames)
           createRouterComponent(routes[routerPath], selector)
-          return
-        }
+          return;
+        } 
       }
     }
 
     // Handle 404
-    if (typeof routes['**'] === "object") {
-      createRouterComponent(routes['**'], selector)
+    if (isObject(routes['*'])) {
+      createRouterComponent(routes['*'], selector)
       return
     }
 

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -71,7 +71,7 @@ export function useRouter(routesArray: Route[]): Router {
     // Assign url params
     params = Object.create(null)
     for (const routerPath of Object.keys(routes)) {
-      // browerPath = 'posts/37739/ahihi-post';
+      // browerPath = 'posts/37739';
       // routerPath = 'posts/:id'
 
       if (includes(routerPath, ":")) {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1,14 +1,45 @@
-export function extractAttribute(obj: object, path: string | string[], value?: any): any {
-  if (typeof path === 'string')
-    return extractAttribute(obj, path.split('.'), value)
-  else if (path.length === 1 && value !== undefined)
+// ------ ROUTER FUNCTIONS ---------
+export function cleanPath(path: string) {
+  // remove leading/trailing slashes + hash symbol
+  // e.g: '#////posts/:id///' -> posts/:id
+  return path.replace(/^[\#]*[\/]*(.*)/, '$1').replace(/\/+$/, '');
+}
+
+export function getParam(paramName: string, url: string) {
+  const href = url || window.location.href;
+  const name = paramName.replace(/[[]]/g, '\\$&');
+  const regex = new RegExp(`[?&]${name}(=([^&#]*)|&|#|$)`);
+  const results = regex.exec(href);
+  if (!results) return null;
+  if (!results[2]) return '';
+  return decodeURIComponent(results[2].replace(/\+/g, ' '));
+}
+
+
+// -------- COMMON FUNCTIONS ----------
+export function convertToArray(arr: any): any {
+  return [...arr]
+}
+
+export function isObject(obj: any) {
+  return typeof obj === 'object'
+}
+
+export function includes(arr: any, id: string | number) {
+  return arr.indexOf(id) !== -1;
+}
+
+export function extractAttribute(obj: object, is: string | string[], value?: any): any {
+  if (typeof is === 'string')
+    return extractAttribute(obj, is.split('.'), value)
+  else if (is.length === 1 && value !== undefined)
     { // @ts-ignore
-      return obj[path[0]] = value
+      return obj[is[0]] = value
     }
-  else if (path.length === 0)
+  else if (is.length === 0)
     return obj
   else
     { // @ts-ignore
-      return extractAttribute(obj[path[0]], path.slice(1), value);
+      return extractAttribute(obj[is[0]], is.slice(1), value);
     }
 }


### PR DESCRIPTION
Yo, RegExp might be a better idea regarding url params parsing. Say we have a routerPath with a param like posts/:id, it could be converted to posts/([^/]+), and later be matched with the actual browser pathname to extract the params.
- [x] utils function to purify the url with hash/slashes
- [x] refactor to capture params with regex (faster than for loop lol).
